### PR TITLE
Help usage and shellcheck fixes

### DIFF
--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -99,7 +99,11 @@ case "$#" in
 
   2)
     case "$1" in --*)
-      case "$2" in -*) exec rbenv-help alias ;; esac
+      case "$2" in -*)
+        rbenv-help --usage alias >&2;
+        exit 1
+        ;;
+      esac
       exec rbenv-alias "$2" "$1" ;;
     esac
     if [ -e "$1" -a ! -L "$1" ]; then
@@ -139,8 +143,12 @@ case "$#" in
           auto_symlink_point $point
         done
         ;;
+      --help)
+        exec rbenv-help alias
+        ;;
       -*)
-        rbenv-help alias
+        rbenv-help --usage alias >&2
+        exit 1
         ;;
       *)
         if [ -L "$1" ]; then
@@ -163,6 +171,7 @@ case "$#" in
     ;;
 
   *)
-    rbenv-help alias
+    rbenv-help --usage alias >&2
+    exit 1
     ;;
 esac

--- a/bin/rbenv-unalias
+++ b/bin/rbenv-unalias
@@ -4,14 +4,22 @@
 #
 # Usage: rbenv unalias <alias> [<alias> ...]
 
+case "$1" in
 # Provide rbenv completions
-if [ --complete = "$1" ]; then
-  rbenv-alias --list | awk '{print $1}'
-  exit 0
-fi
-
-[ $# -gt 0 ] || exec rbenv-help alias
-
-for arg in "$@"; do
-  rbenv-alias "$arg" --remove
-done
+  --complete)
+    rbenv-alias --list | awk '{print $1}'
+    exit 0
+    ;;
+  --help)
+    exec rbenv-help unalias
+    ;;
+  "")
+    rbenv-help --usage unalias >&2
+    exit 1
+    ;;
+  *)
+    for arg in "$@"; do
+      rbenv-alias "$arg" --remove
+    done
+    ;;
+esac

--- a/etc/rbenv.d/install/autoalias.bash
+++ b/etc/rbenv.d/install/autoalias.bash
@@ -4,7 +4,7 @@ autoalias() {
   if [ "$STATUS" = 0 ]; then
     case "$VERSION_NAME" in
       *[0-9]-*-*)
-        local patch="$(echo $VERSION_NAME|sed -e 's/-[^-]*$//')"
+        local patch="${VERSION_NAME%-*}"
         if [ ! -e "$RBENV_ROOT/$patch" ]; then
           # rbenv alias 1.9.3-p194 1.9.3-p194-perf
           rbenv alias "$patch" "$VERSION_NAME"
@@ -13,7 +13,7 @@ autoalias() {
     esac
     case "$VERSION_NAME" in
       *[0-9]-*)
-        rbenv alias "$(echo "$VERSION_NAME"|sed -e 's/-.*$//')" --auto 2>/dev/null || true
+        rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true
         ;;
     esac
   fi


### PR DESCRIPTION
shellcheck fixes

fixed some things that [shellcheck](http://www.shellcheck.net/) static analysis found
- SC2164: Use cd ... || exit in case cd fails.
- SC2035: Use ./\* so names with dashes won't become options.
- SC2086: Double quote to prevent globbing and word splitting.
- SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
- SC2155: Declare and assign separately to avoid masking return values.
- SC2035: Use ./_._._-_ so names with dashes won't become options.
- SC2035: Use ./_-_._._ so names with dashes won't become options.

only print --usage help, not entire help output when given unknown args

remove extraneous 'exec'

Tests are failing on master and failing for identical reasons on this branch.
