### PR TITLE
Fix bugs with --auto

### DIFF
--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -80,10 +80,10 @@ point_releases() {
   echo_lines_without_symlinks *.*.*-*|sed -e 's/-.*//'|sort -u
 
   # jruby-1.7.3
-  echo_lines_without_symlinks *-*.*.*|sed -e 's/\.[0-9]\+$//'|sort -u
+  echo_lines_without_symlinks *-*.*.*|sed -e 's/\.[0-9]*$//'|sort -u
 
   # 2.1.4
-  echo_lines_without_symlinks [0-9].[0-9].[0-9]|sed -e 's/\.[0-9]\+$//'|sort -u
+  echo_lines_without_symlinks [0-9].[0-9].[0-9]|sed -e 's/\.[0-9]*$//'|sort -u
 }
 
 # Provide rbenv completions

--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -55,13 +55,13 @@ echo_lines_without_symlinks() {
 }
 
 auto_for_point() {
-  local highest="$(echo_lines_without_symlinks $1*|sort -n|tail -1)"
-  if [ "$highest" != "${highest%-p*}" ]; then
-    local patch="$(echo_lines_without_symlinks $1*|sed -e 's/.*-p//'|sort -n|tail -1)"
-    echo "$1-p$patch"
-  else
-    echo "$highest"
-  fi
+  case "$1" in
+    # 1.9.3-p123
+    *.*.*) echo_lines_without_symlinks $1* | sort -n -k 1.$((3 + ${#1})) | tail -1 ;;
+
+    # 2.1.4 or jruby-1.7.3
+    *.*)   echo_lines_without_symlinks $1* | sort -n -k 1.$((2 + ${#1})) | tail -1 ;;
+  esac
 }
 
 auto_symlink_point() {
@@ -123,7 +123,7 @@ case "$#" in
       fi
     elif [ --auto = "$2" ]; then
       case "$1" in
-        *.*.*)
+        *.*)
           auto_symlink_point "$1"
           ;;
         *)

--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -56,7 +56,12 @@ echo_lines_without_symlinks() {
 
 auto_for_point() {
   local highest="$(echo_lines_without_symlinks $1*|sort -n|tail -1)"
-  echo "$highest"
+  if [ "$highest" != "${highest%-p*}" ]; then
+    local patch="$(echo_lines_without_symlinks $1*|sed -e 's/.*-p//'|sort -n|tail -1)"
+    echo "$1-p$patch"
+  else
+    echo "$highest"
+  fi
 }
 
 auto_symlink_point() {

--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -54,14 +54,15 @@ echo_lines_without_symlinks() {
   done
 }
 
-auto_for_point() {
+patch_start_point() {
   case "$1" in
-    # 1.9.3-p123
-    *.*.*) echo_lines_without_symlinks $1* | sort -n -k 1.$((3 + ${#1})) | tail -1 ;;
-
-    # 2.1.4 or jruby-1.7.3
-    *.*)   echo_lines_without_symlinks $1* | sort -n -k 1.$((2 + ${#1})) | tail -1 ;;
+    *.*.*) echo $((3 + ${#1})) ;; # point_release string length + 1 (0 indexed) + 2 for `-p` separator
+    *.*)   echo $((2 + ${#1})) ;; # point_release string length + 1 (0 indexed) + 1 for `.` separator
   esac
+}
+
+auto_for_point() {
+  echo_lines_without_symlinks $1* | sort -n -k 1."$(patch_start_point "$1")" | tail -1
 }
 
 auto_symlink_point() {

--- a/test/alias.bats
+++ b/test/alias.bats
@@ -37,9 +37,13 @@ load test_helper
 @test "rbenv-alias --auto" {
   create_versions 1.8.7-p371      1.8.7-p99        1.8.7-p100
   create_versions 1.2.3-p99-perf  1.2.3-p234-beta  1.2.3-p1-perf
+  create_versions jruby-1.7.2     jruby-1.7.11
+  create_versions 2.1.5           2.1.40
 
   run rbenv-alias --auto
   assert_success
   assert_alias_version 1.8.7 1.8.7-p371
   assert_alias_version 1.2.3 1.2.3-p234-beta
+  assert_alias_version jruby-1.7 jruby-1.7.11
+  assert_alias_version 2.1 2.1.40
 }

--- a/test/alias.bats
+++ b/test/alias.bats
@@ -10,6 +10,22 @@ load test_helper
   assert_alias_version 1.8.7 1.8.7-p371
 }
 
+@test "rbenv-alias jruby-1.7 --auto with jruby" {
+  create_versions jruby-1.7.2  jruby-1.7.11
+
+  run rbenv-alias jruby-1.7 --auto
+  assert_success
+  assert_alias_version jruby-1.7 jruby-1.7.11
+}
+
+@test "rbenv-alias 2.1 --auto with semver" {
+  create_versions 2.1.5  2.1.40
+
+  run rbenv-alias 2.1 --auto
+  assert_success
+  assert_alias_version 2.1 2.1.40
+}
+
 @test "rbenv-alias name 1.8.7-p100" {
   create_versions 1.8.7-p371  1.8.7-p99  1.8.7-p100
 

--- a/test/alias.bats
+++ b/test/alias.bats
@@ -3,9 +3,7 @@
 load test_helper
 
 @test "rbenv-alias 1.8.7 --auto" {
-  create_versions 1.8.7-p371
-  create_versions 1.8.7-p99
-  create_versions 1.8.7-p100
+  create_versions 1.8.7-p371  1.8.7-p99  1.8.7-p100
 
   run rbenv-alias 1.8.7 --auto
   assert_success
@@ -13,9 +11,7 @@ load test_helper
 }
 
 @test "rbenv-alias name 1.8.7-p100" {
-  create_versions 1.8.7-p371
-  create_versions 1.8.7-p99
-  create_versions 1.8.7-p100
+  create_versions 1.8.7-p371  1.8.7-p99  1.8.7-p100
 
   run rbenv-alias name 1.8.7-p100
   assert_success
@@ -23,17 +19,11 @@ load test_helper
 }
 
 @test "rbenv-alias --auto" {
-  create_versions 1.8.7-p371
-  create_versions 1.8.7-p99
-  create_versions 1.8.7-p100
-
-  create_versions 1.2.3-p99-perf
-  create_versions 1.2.3-p234-beta
-  create_versions 1.2.3-p1-perf
+  create_versions 1.8.7-p371      1.8.7-p99        1.8.7-p100
+  create_versions 1.2.3-p99-perf  1.2.3-p234-beta  1.2.3-p1-perf
 
   run rbenv-alias --auto
   assert_success
   assert_alias_version 1.8.7 1.8.7-p371
   assert_alias_version 1.2.3 1.2.3-p234-beta
-
 }


### PR DESCRIPTION
Found a few bugs with how --auto works.

When the semver support was added, it broke the existing tests, but was never caught.

1. `rbenv alias <version> --auto` never even accepted semver style or jruby-1.2.3 style versions. The argument typically passed here is the intended symlink, so the case statement only accepted 1.2.3 (which would be the argument to match 1.2.3-pXXX). So I relaxed the case statement to accept X.Y (which would be the minimal argument to auto alias a semver version: 1.2 -> 1.2.3).
2. `rbenv alias <version> --auto` wasn't sorting the patch version correctly. (This has been broken since 2e752b0df250104b55cc9cf54414de77626cf8bd, to my knowledge)
    - it would sort p99 above p145
    - it would sort 1.2.5 above 1.2.40
    - it would sort jruby-1.7.2 above jruby-1.7.11

    My approach for sorting the patch versions correctly is to derive/guess the character index at which the patch version begins. (For, -p style that's the length of the point_release string +3: 2 for -p and 1 for 0-based-indexing. For 1.2.3/rbx-1.2.3 style, that's the length of the point_release string +2: 1 for the . and 1 for 0-based-indexing.) Knowing the character index of the patch version, we can use the -k argument to sort.
3. `rbenv alias --auto` apparently didn't work correctly either, because the `point_releases` function (intended to return all non-symlink versions without their patch fields) had a mistake in the sed expression. It was stripping off a trailing {dot}{digit}{literal +}. The `+` meant as a quantity operator for the digit class was being escaped so it was searching for a literal trailing `+`. Which meant that semver and rbx-1.2.3 versions never got truncated. (So, for example, it would attempt to create a symlink for rbx-1.2.3 as rbx-1.2.3, instead of rbx-1.2.)  I'm assuming the escape was mistakenly added to the `+` because `+` is not a valid quantifier with sed Basic Regular Expressions. Ideally, we would use extended regexes, but the flag for e-regex differs between gnu/linux (-r) and bsd (-E). So instead, I just changed the expression to end with `[0-9]*`. Technically, this will match and truncate a single trailing `.`, but I suspect that is rare enough to not warrant the kludgy alternatives to using extended regexes. If you have a better suggestion, there's room to improve here.

Since the existing test suite isn't already running on travis, you can see the travis build of my fork here: https://travis-ci.org/jasonkarns/rbenv-aliases/builds/95101958