### PR TITLE
AfterInstall hook doesn't auto alias -p123-foo

### DIFF
--- a/etc/rbenv.d/install/autoalias.bash
+++ b/etc/rbenv.d/install/autoalias.bash
@@ -3,18 +3,10 @@ after_install autoalias
 autoalias() {
   if [ "$STATUS" = 0 ]; then
     case "$VERSION_NAME" in
-      *[0-9]-*-*)
-        local patch="${VERSION_NAME%-*}"
-        if [ ! -e "$RBENV_ROOT/$patch" ]; then
-          # rbenv alias 1.9.3-p194 1.9.3-p194-perf
-          rbenv alias "$patch" "$VERSION_NAME"
-        fi
-        ;;
+      *[0-9]-*-*) rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true ;;
     esac
     case "$VERSION_NAME" in
-      *[0-9]-*)
-        rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true
-        ;;
+      *[0-9]-*) rbenv alias "${VERSION_NAME%%-*}" --auto 2>/dev/null || true ;;
     esac
   fi
 }

--- a/etc/rbenv.d/install/autoalias.bash
+++ b/etc/rbenv.d/install/autoalias.bash
@@ -3,10 +3,10 @@ after_install autoalias
 autoalias() {
   if [ "$STATUS" = 0 ]; then
     case "$VERSION_NAME" in
-      *[0-9]-*-*) rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true ;;
-    esac
-    case "$VERSION_NAME" in
-      *[0-9]-*) rbenv alias "${VERSION_NAME%%-*}" --auto 2>/dev/null || true ;;
+    *[0-9]-*)
+      rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true
+      rbenv alias "${VERSION_NAME%%-*}" --auto 2>/dev/null || true
+      ;;
     esac
   fi
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -22,5 +22,11 @@ load test_helper
   assert_line 'Installed fake version 1.9.3-p200'
   assert_line '1.9.3 => 1.9.3-p200'
 
+  run rbenv-install 1.9.3-p456-perf
+  assert_success
+  assert_alias_version 1.9.3 1.9.3-p456-perf
+  assert_alias_version 1.9.3-p456 1.9.3-p456-perf
+  assert_line 'Installed fake version 1.9.3-p456-perf'
+  assert_line '1.9.3 => 1.9.3-p456-perf'
+  assert_line '1.9.3-p456 => 1.9.3-p456-perf'
 }
-


### PR DESCRIPTION
After installing a version with two hyphens (i.e. 1.9.3-p123-perf), the
after install hook ought to create two aliases:

1. 1.9.3
2. 1.9.3-p123

Shamefully, I'm the author of this regression: cd4d537