### PR TITLE
Refactor out 'abort' helper

### DIFF
--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -86,6 +86,14 @@ point_releases() {
   echo_lines_without_symlinks [0-9].[0-9].[0-9]|sed -e 's/\.[0-9]*$//'|sort -u
 }
 
+abort() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "rbenv-alias: $*"
+    fi
+  } >&2
+  exit 1
+}
+
 # Provide rbenv completions
 if [ --complete = "$1" ]; then
   shift
@@ -105,32 +113,18 @@ case "$#" in
 
   2)
     case "$1" in --*)
-      case "$2" in -*)
-        rbenv-help --usage alias >&2;
-        exit 1
-        ;;
-      esac
+      case "$2" in -*) abort < <(rbenv-help --usage alias) ;; esac
       exec rbenv-alias "$2" "$1" ;;
     esac
-    if [ -e "$1" -a ! -L "$1" ]; then
-      echo "Not clobbering $1" >&2
-      exit 1
+    if [ -e "$1" -a ! -L "$1" ]; then abort "Not clobbering $1"
     elif [ --remove = "$2" ]; then
-      if [ -L "$1" ]; then
-        rm "$1"
-      else
-        echo "No such alias $1" >&2
-        exit 1
+      if [ -L "$1" ]; then rm "$1"
+      else abort "No such alias $1"
       fi
     elif [ --auto = "$2" ]; then
       case "$1" in
-        *.*)
-          cleanup_invalid "$1" && auto_symlink_point "$1"
-          ;;
-        *)
-          echo "Don't know how to automatically alias $1" >&2
-          exit 1
-          ;;
+        *.*) cleanup_invalid "$1" && auto_symlink_point "$1" ;;
+        *) abort "Don't know how to automatically alias $1" ;;
       esac
     else
       echo "$1 => $2"
@@ -153,31 +147,18 @@ case "$#" in
         exec rbenv-help alias
         ;;
       -*)
-        rbenv-help --usage alias >&2
-        exit 1
+        abort < <(rbenv-help --usage alias)
         ;;
       *)
-        if [ -L "$1" ]; then
-          readlink "$1"
-        elif [ -d "$1" ]; then
-          echo "$1 is an install, not an alias" >&2
-          exit 1
-        elif [ -e "$1" ]; then
-          echo "$1 exists but is not an alias" >&2
-          exit 1
-        else
-          echo "$1 does not exist" >&2
-          exit 1
+        if [ -L "$1" ]; then readlink "$1"
+        elif [ -d "$1" ]; then abort "$1 is an install, not an alias"
+        elif [ -e "$1" ]; then abort "$1 exists but is not an alias"
+        else abort "$1 does not exist"
         fi
     esac
     ;;
 
-  0)
-    list
-    ;;
+  0) list ;;
 
-  *)
-    rbenv-help --usage alias >&2
-    exit 1
-    ;;
+  *) abort < <(rbenv-help --usage alias) ;;
 esac


### PR DESCRIPTION
Add `abort` helper
- prints message to stderr
- accepts message via argument or stdin
- prepends 'rbenv-alias: ' to message
- exits with code 1