### PR TITLE
Fix autoalias hooks for semver versions

### DIFF
--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -54,15 +54,19 @@ echo_lines_without_symlinks() {
   done
 }
 
-patch_start_point() {
+sort_versions() {
+  local patch_start_point
+
   case "$1" in
-    *.*.*) echo $((3 + ${#1})) ;; # point_release string length + 1 (0 indexed) + 2 for `-p` separator
-    *.*)   echo $((2 + ${#1})) ;; # point_release string length + 1 (0 indexed) + 1 for `.` separator
+    *.*.*) patch_start_point=$((${#1} + 3)) ;; # point_release string length + 1 (0 indexed) + 2 for `-p` separator
+    *.*)   patch_start_point=$((${#1} + 2)) ;; # point_release string length + 1 (0 indexed) + 1 for `.` separator
   esac
+
+  sort -n -k "1.$patch_start_point"
 }
 
 auto_for_point() {
-  echo_lines_without_symlinks $1* | sort -n -k 1."$(patch_start_point "$1")" | tail -1
+  echo_lines_without_symlinks $1* | sort_versions "$1" | tail -1
 }
 
 auto_symlink_point() {

--- a/bin/rbenv-alias
+++ b/bin/rbenv-alias
@@ -80,14 +80,7 @@ auto_symlink_point() {
 }
 
 point_releases() {
-  # 1.9.3-p123
-  echo_lines_without_symlinks *.*.*-*|sed -e 's/-.*//'|sort -u
-
-  # jruby-1.7.3
-  echo_lines_without_symlinks *-*.*.*|sed -e 's/\.[0-9]*$//'|sort -u
-
-  # 2.1.4
-  echo_lines_without_symlinks [0-9].[0-9].[0-9]|sed -e 's/\.[0-9]*$//'|sort -u
+  echo_lines_without_symlinks *.*.* | sed -e 's/\.[^-.]*$//' -e 's/-[^.]*$//' | sort -u
 }
 
 abort() {

--- a/etc/rbenv.d/install/autoalias.bash
+++ b/etc/rbenv.d/install/autoalias.bash
@@ -7,6 +7,9 @@ autoalias() {
       rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true
       rbenv alias "${VERSION_NAME%%-*}" --auto 2>/dev/null || true
       ;;
+    *.*.*)
+      rbenv alias "${VERSION_NAME%.*}" --auto 2>/dev/null || true
+      ;;
     esac
   fi
 }

--- a/etc/rbenv.d/uninstall/autoalias.bash
+++ b/etc/rbenv.d/uninstall/autoalias.bash
@@ -6,5 +6,8 @@ autoalias() {
     rbenv alias "${VERSION_NAME%-*}" --auto 2>/dev/null || true
     rbenv alias "${VERSION_NAME%%-*}" --auto 2>/dev/null || true
     ;;
+  *.*.*)
+    rbenv alias "${VERSION_NAME%.*}" --auto 2>/dev/null || true
+    ;;
   esac
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -4,29 +4,34 @@ load test_helper
 
 @test "running rbenv-install auto installs an alias" {
 
+  run rbenv-install 2.1.5
+  assert_success
+  assert_line 'Installed fake version 2.1.5'
+  assert_line '2.1 => 2.1.5'
+  assert_alias_version 2.1 2.1.5
+
   run rbenv-install 1.9.3-p123
   assert_success
   assert_line 'Installed fake version 1.9.3-p123'
   assert_line '1.9.3 => 1.9.3-p123'
-
   assert_alias_version 1.9.3 1.9.3-p123
 
   run rbenv-install 1.9.3-p99
   assert_success
-  assert_alias_version 1.9.3 1.9.3-p123
   assert_line 'Installed fake version 1.9.3-p99'
+  assert_alias_version 1.9.3 1.9.3-p123
 
   run rbenv-install 1.9.3-p200
   assert_success
-  assert_alias_version 1.9.3 1.9.3-p200
   assert_line 'Installed fake version 1.9.3-p200'
   assert_line '1.9.3 => 1.9.3-p200'
+  assert_alias_version 1.9.3 1.9.3-p200
 
   run rbenv-install 1.9.3-p456-perf
   assert_success
-  assert_alias_version 1.9.3 1.9.3-p456-perf
-  assert_alias_version 1.9.3-p456 1.9.3-p456-perf
   assert_line 'Installed fake version 1.9.3-p456-perf'
   assert_line '1.9.3 => 1.9.3-p456-perf'
   assert_line '1.9.3-p456 => 1.9.3-p456-perf'
+  assert_alias_version 1.9.3 1.9.3-p456-perf
+  assert_alias_version 1.9.3-p456 1.9.3-p456-perf
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -64,13 +64,13 @@ assert_alias_version() {
     echo "Versions:"
     (cd $RBENV_ROOT/versions ; ls -l)
   fi
-  assert_equal "$2" `cat $RBENV_ROOT/versions/$1/RELEASE.txt 2>&1`
+  assert_equal "$2" "$(cat "$RBENV_ROOT/versions/$1/RELEASE.txt" 2>&1)"
 }
 
 assert_alias_missing() {
   if [ -f $RBENV_ROOT/versions/$1/RELEASE.txt ]
   then
-    assert_equal "no-version" `cat $RBENV_ROOT/versions/$1/RELEASE.txt 2>&1`
+    assert_equal "no-version" "$(cat "$RBENV_ROOT/versions/$1/RELEASE.txt" 2>&1)"
   fi
 }
 

--- a/test/uninstall.bats
+++ b/test/uninstall.bats
@@ -27,6 +27,19 @@ load test_helper
   assert_alias_version 1.9.3 1.9.3-p123
 }
 
+@test "running rbenv-uninstall auto updates the alias to highest remaining semver version" {
+  create_versions 2.1.3 2.1.5
+  create_alias 2.1 2.1.5
+
+  run rbenv-uninstall 2.1.5
+
+  assert_success
+  assert_line 'Uninstalled fake version 2.1.5'
+  assert_line_starts_with 'Removing invalid link from 2.1'
+  assert_line '2.1 => 2.1.3'
+  assert_alias_version 2.1 2.1.3
+}
+
 @test "running rbenv-uninstall auto updates the alias to highest remaining version, handling multi-segment patches" {
   create_versions 1.9.3-p123 1.9.3-p456-perf
   create_alias 1.9.3 1.9.3-p456-perf


### PR DESCRIPTION
- Semver versions weren't being autoaliased after install/uninstall.
- Also improves error message from `assert_alias_version` and `assert_alias_missing` helpers.
- Now supports auto-aliasing semver versions with a version segment >= 10 (previously, a version such as 2.10.1 couldn't be autoaliased)
Includes minor refactor of version sorting function.