### PR TITLE
Clone with HTTP instead of SSH

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,8 +19,8 @@ having to reinstall gems every time you install a new patch release, check out
 ## Installation
 
     mkdir -p "$(rbenv root)/plugins"
-    git clone git://github.com/tpope/rbenv-aliases.git \
-      "$(rbenv root)/plugins/rbenv-aliases"
+    git clone https://github.com/tpope/rbenv-aliases.git \
+      "$(rbenv root)/plugins/rbenv-aliases" &&\
     rbenv alias --auto
 
 [rbenv]: https://github.com/sstephenson/rbenv


### PR DESCRIPTION
If SSH keys aren't configured, we got an error:

```bash
~$ git clone git://github.com/tpope/rbenv-aliases.git \
  "$(rbenv root)/plugins/rbenv-aliases"
rbenv alias --auto
Cloning into '/home/virtual/.rbenv/plugins/rbenv-aliases'... fatal: read error: Connection reset by peer
rbenv: no such command `alias'
```

Not all users use SSH keys.